### PR TITLE
bump clr-loader version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = {text = "MIT"}
 readme = "README.rst"
 
 dependencies = [
-    "clr_loader>=0.2.2,<0.3.0"
+    "clr_loader>=0.2.5,<0.3.0"
 ]
 
 requires-python = ">=3.7, <3.12"


### PR DESCRIPTION
This allows pythonnet to work in the version of mono we ship with the unified install

I made the change in clr_loader in this PR:
https://github.com/pythonnet/clr-loader/pull/43
